### PR TITLE
Subscribed to another event in order to trigger theme change on story change

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -102,8 +102,8 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
 
   React.useEffect(() => {
     const channel = props.api.getChannel();
-    channel.on('storyChanged', () => renderTheme());
-    channel.on('storiesConfigured', () => renderTheme());
+    channel.on('storyChanged', renderTheme);
+    channel.on('storiesConfigured', renderTheme);
   }, []);
 
   return (

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -73,36 +73,37 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
       ...currentStore,
       current
     });
-
     props.api.setOptions({ theme: currentStore[current] });
     setDark(!isDark);
     props.channel.emit('DARK_MODE', !isDark);
   }
 
+  function renderTheme() {
+    const { parameters } = props.api.getCurrentStoryData();
+
+    let darkTheme = themes.dark;
+    let lightTheme = themes.light;
+
+    if (parameters && parameters.darkMode) {
+      darkTheme = parameters.darkMode.dark || darkTheme;
+      lightTheme = parameters.darkMode.light || lightTheme;
+    }
+
+    const currentStore = store({
+      light: lightTheme,
+      dark: darkTheme
+    });
+    const { current } = currentStore;
+
+    props.api.setOptions({ theme: currentStore[current] });
+    setDark(current === 'dark');
+    props.channel.emit('DARK_MODE', current === 'dark');
+  }
+
   React.useEffect(() => {
     const channel = props.api.getChannel();
-
-    channel.on('storiesConfigured', () => {
-      const { parameters } = props.api.getCurrentStoryData();
-
-      let darkTheme = themes.dark;
-      let lightTheme = themes.light;
-
-      if (parameters && parameters.darkMode) {
-        darkTheme = parameters.darkMode.dark || darkTheme;
-        lightTheme = parameters.darkMode.light || lightTheme;
-      }
-
-      const currentStore = store({
-        light: lightTheme,
-        dark: darkTheme
-      });
-      const { current } = currentStore;
-
-      props.api.setOptions({ theme: currentStore[current] });
-      setDark(current === 'dark');
-      props.channel.emit('DARK_MODE', current === 'dark');
-    });
+    channel.on('storyChanged', () => renderTheme());
+    channel.on('storiesConfigured', () => renderTheme());
   }, []);
 
   return (


### PR DESCRIPTION
**What does this PR do?**
This PR fixes a bug related to the moment in which we navigate through stories with a theme different to the base configured theme.

In order to fix it we will subscribe to another event that will trigger the same exact logic that the one triggered on stories configured.

It fixes issue: https://github.com/hipstersmoothie/storybook-dark-mode/issues/9