### PR TITLE
Listen for `docsRendered` event so it also picks up the correct theme.

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -104,6 +104,7 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
     const channel = props.api.getChannel();
     channel.on('storyChanged', renderTheme);
     channel.on('storiesConfigured', renderTheme);
+    channel.on('docsRendered', renderTheme);
   }, []);
 
   return (


### PR DESCRIPTION
This allows the plugin to work on the docs pages from the new [`addon-docs`](https://medium.com/storybookjs/storybook-docspage-e185bc3622bf).