### PR TITLE
Create a React hook for getting dark-mode state

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,29 @@ addParameters({
 
 ## Story integration
 
-If your components use a custom Theme provider, you can integrate it by adding decorator that listens for the `DARK_MODE` event via the addons channel.
+If your components use a custom Theme provider, you can integrate it by using the provided hook.
+
+```js
+import { useDarkMode } from 'storybook-dark-mode';
+import { addDecorator } from '@storybook/react';
+
+// your theme provider
+import ThemeContext from './theme';
+
+// create a component that uses the dark mode hook
+function ThemeWrapper(props) {
+  // render your custom theme provider
+  return (
+    <ThemeContext.Provider value={useDarkMode() ? darkTheme : defaultTheme}>
+      {props.children}
+    </ThemeContext.Provider>
+  );
+}
+
+addDecorator(renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>);
+```
+
+You can also listen for the `DARK_MODE` event via the addons channel.
 
 ```js
 import addons from '@storybook/addons';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storybook-dark-mode",
   "version": "0.2.0",
   "description": "Toggle between light and dark mode in Storybook v5",
-  "main": "index.js",
+  "main": "dist/index.js",
   "source": "index.ts",
   "files": [
     "dist",

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -3,6 +3,7 @@ import { themes, ThemeVars } from '@storybook/theming';
 import { IconButton } from '@storybook/components';
 import { API } from '@storybook/api';
 import equal from 'fast-deep-equal';
+import { DARK_MODE_EVENT_NAME } from './constants';
 
 import Sun from './icons/Sun';
 import Moon from './icons/Moon';
@@ -66,7 +67,7 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
     });
     props.api.setOptions({ theme: currentStore[current] });
     setDark(!isDark);
-    props.api.getChannel().emit('DARK_MODE', !isDark);
+    props.api.getChannel().emit(DARK_MODE_EVENT_NAME, !isDark);
   }
 
   function prefersDarkUpdate(event: MediaQueryListEvent) {
@@ -97,7 +98,7 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
 
     props.api.setOptions({ theme: currentStore[current] });
     setDark(current === 'dark');
-    props.api.getChannel().emit('DARK_MODE', current === 'dark');
+    props.api.getChannel().emit(DARK_MODE_EVENT_NAME, current === 'dark');
   }
 
   React.useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const DARK_MODE_EVENT_NAME = 'DARK_MODE';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import addons from '@storybook/addons';
+import { DARK_MODE_EVENT_NAME } from './constants';
+
+/**
+ * Returns the current state of storybook's dark-mode
+ */
+export function useDarkMode(): boolean {
+  const [isDark, setDark] = React.useState(false);
+
+  React.useEffect(() => {
+    const chan = addons.getChannel();
+    chan.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => chan.off(DARK_MODE_EVENT_NAME, setDark);
+  }, []);
+
+  return isDark;
+}
+
+export * from './constants';


### PR DESCRIPTION
Allows any component to use the hook in their Component to fetch the current state of dark-mode.

Here I'm using the hook to set the `theme` on a monoco editor in the addons panel

![Screen Recording 2020-02-03 at 4 59 21 PM](https://user-images.githubusercontent.com/13004162/73704032-b5fd1900-46a6-11ea-9666-ed6e664de97b.gif)
