### PR TITLE
Fix undefined story data

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -77,7 +77,7 @@ export const DarkMode: React.FunctionComponent<DarkModeProps> = props => {
   function renderTheme() {
     const data = props.api.getCurrentStoryData();
 
-    if (!('parameters' in data)) {
+    if (!(data && 'parameters' in data)) {
       return;
     }
 


### PR DESCRIPTION
I was getting this error in my storybook for a svelte project:
```
TypeError: Cannot use 'in' operator to search for 'parameters' in undefined
    at renderTheme (vendors~main.44b08c472af3b68560ea.bundle.js:204953)
```

I added a check to see if the current story data is undefined before checking if it contains the "parameters" key.

I'm not sure why getCurrentStoryData() is returning null, but now renderTheme() can handle it.