### PR TITLE
add dark/light class to manager + optionally set classes on the preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,41 @@ addParameters({
 });
 ```
 
+### Dark/Light Class
+
+This plugin will apply a dark and light class name to the manager.
+This allows you to easily write dark mode aware theme overrides for the storybook UI.
+
+You can override the classNames applied when switching between light and dark mode using the `darkClass` and `lightClass` parameters.
+
+```js
+import { addParameters } from '@storybook/react';
+
+addParameters({
+  darkMode: {
+    darkClass: 'lights-out',
+    lightClass: 'lights-on'
+  }
+});
+```
+
 ## Story integration
+
+### Preview ClassName
+
+This plugin will apply the `darkClass` and `lightClass` classes to the preview iframe if you turn on the `stylePreview` option.
+
+```js
+import { addParameters } from '@storybook/react';
+
+addParameters({
+  darkMode: {
+    stylePreview: true
+  }
+});
+```
+
+### React
 
 If your components use a custom Theme provider, you can integrate it by using the provided hook.
 
@@ -86,6 +120,38 @@ function ThemeWrapper(props) {
 
 addDecorator(renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>);
 ```
+
+#### Theme Knobs
+
+If you want to have you UI's dark mode separate from you components' dark mode, implement this global decorator:
+
+```js
+// Add a global decorator that will render a dark background when the
+// "Color Scheme" knob is set to dark
+addDecorator(function(storyFn) {
+  // A knob for color scheme added to every story
+  const colorScheme = select('Color Scheme', ['light', 'dark'], 'light');
+
+  // Hook your theme provider with some knobs
+  return React.createElement(ThemeProvider, {
+    // A knob for theme added to every story
+    theme: select('Theme', Object.keys(themes), 'default'),
+    colorScheme,
+    children: [
+      React.createElement('style', {
+        dangerouslySetInnerHTML: {
+          __html: `html { ${
+            colorScheme === 'dark' ? 'background-color: rgb(35,35,35);' : ''
+          } }`
+        }
+      }),
+      storyFn()
+    ]
+  });
+});
+```
+
+### Events
 
 You can also listen for the `DARK_MODE` event via the addons channel.
 
@@ -119,34 +185,6 @@ function ThemeWrapper(props) {
 }
 
 addDecorator(renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>);
-```
-
-Or if you want to have you UI's dark mode seperate from you components' dark mode, implement this global decorator:
-
-```js
-// Add a global decorator that will render a dark background when the
-// "Color Scheme" knob is set to dark
-addDecorator(function(storyFn) {
-  // A knob for color scheme added to every story
-  const colorScheme = select('Color Scheme', ['light', 'dark'], 'light');
-
-  // Hook your theme provider with some knobs
-  return React.createElement(ThemeProvider, {
-    // A knob for theme added to every story
-    theme: select('Theme', Object.keys(themes), 'default'),
-    colorScheme,
-    children: [
-      React.createElement('style', {
-        dangerouslySetInnerHTML: {
-          __html: `html { ${
-            colorScheme === 'dark' ? 'background-color: rgb(35,35,35);' : ''
-          } }`
-        }
-      }),
-      storyFn()
-    ]
-  });
-});
 ```
 
 ## Contributors ✨

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -27,6 +27,8 @@ interface DarkModeStore {
   light: ThemeVars;
   /** The light class name for the preview iframe */
   lightClass: string;
+  /** Apply mode to iframe */
+  stylePreview: boolean;
 }
 
 const STORAGE_KEY = 'sb-addon-themes-3';
@@ -34,16 +36,30 @@ const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
 const defaultParams: Partial<DarkModeStore> = {
   dark: themes.dark,
-  light: themes.light
+  darkClass: 'dark',
+  light: themes.light,
+  lightClass: 'light',
+  stylePreview: false,
 };
 
 /** Persist the dark mode settings in localStorage */
-const update = (newStore: DarkModeStore) => {
+const updateStore = (newStore: DarkModeStore) => {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(newStore));
 };
 
+/** Add the light/dark class to an element */
+const toggleDarkClass = (el: HTMLElement, { current, darkClass, lightClass }: DarkModeStore) => {
+  if (current === 'dark') {
+    el.classList.add(darkClass);
+    el.classList.remove(lightClass);
+  } else {
+    el.classList.add(lightClass);
+    el.classList.remove(darkClass);
+  }
+}
+
 /** Update the preview iframe class */
-const updatePreview = (newStore: DarkModeStore) => {
+const updatePreview = (store: DarkModeStore) => {
   const iframe = document.getElementById('storybook-preview-iframe') as HTMLIFrameElement;
 
   if (!iframe) {
@@ -53,40 +69,43 @@ const updatePreview = (newStore: DarkModeStore) => {
   const iframeDocument = iframe.contentDocument || iframe.contentWindow?.document;
   const body = iframeDocument?.body as HTMLBodyElement;
 
-  const { current, darkClass, lightClass } = newStore;
+  toggleDarkClass(body, store);
+};
 
-  if (current === 'dark') {
-    body.classList.add(darkClass || 'dark');
-    body.classList.remove(lightClass || 'light');
-  } else {
-    body.classList.add(lightClass || 'light');
-    body.classList.remove(darkClass || 'dark');
+/** Update the manager iframe class */
+const updateManager = (store: DarkModeStore) => {
+  const manager = document.getElementById('body') as HTMLBodyElement;
+
+  if (!manager) {
+    return;
   }
+
+  toggleDarkClass(manager, store)
 };
 
 /** Update changed dark mode settings and persist to localStorage  */
-const store = (themes: Partial<DarkModeStore> = {}): DarkModeStore => {
+const store = (userTheme: Partial<DarkModeStore> = {}): DarkModeStore => {
   const storedItem = window.localStorage.getItem(STORAGE_KEY);
 
   if (typeof storedItem === 'string') {
     const stored: DarkModeStore = JSON.parse(storedItem);
 
-    if (themes) {
-      if (themes.dark && !equal(stored.dark, themes.dark)) {
-        stored.dark = themes.dark;
-        update(stored);
+    if (userTheme) {
+      if (userTheme.dark && !equal(stored.dark, userTheme.dark)) {
+        stored.dark = userTheme.dark;
+        updateStore(stored);
       }
 
-      if (themes.light && !equal(stored.light, themes.light)) {
-        stored.light = themes.light;
-        update(stored);
+      if (userTheme.light && !equal(stored.light, userTheme.light)) {
+        stored.light = userTheme.light;
+        updateStore(stored);
       }
     }
 
     return stored;
   }
 
-  return { ...defaultParams, ...themes } as DarkModeStore;
+  return { ...defaultParams, ...userTheme } as DarkModeStore;
 };
 
 interface DarkModeProps {
@@ -97,12 +116,9 @@ interface DarkModeProps {
 /** A toolbar icon to toggle between dark and light themes in storybook */
 export const DarkMode = ({ api }: DarkModeProps) => {
   const [isDark, setDark] = React.useState(prefersDark.matches);
-  const { current: defaultMode, ...params } = useParameter<
+  const { current: defaultMode, stylePreview, ...params } = useParameter<
     Partial<DarkModeStore>
-  >('darkMode', {
-    dark: themes.dark,
-    light: themes.light
-  });
+  >('darkMode', defaultParams);
   // const lastMode = React.useRef(defaultMode);
 
   // Save custom themes on init
@@ -116,9 +132,13 @@ export const DarkMode = ({ api }: DarkModeProps) => {
       api.setOptions({ theme: currentStore[mode] });
       setDark(mode === 'dark');
       api.getChannel().emit(DARK_MODE_EVENT_NAME, mode === 'dark');
-      updatePreview(currentStore);
+      updateManager(currentStore)
+
+      if (stylePreview) {
+        updatePreview(currentStore);
+      }
     },
-    [api]
+    [api, stylePreview]
   );
 
   /** Update the theme settings in localStorage, react, and storybook */
@@ -128,7 +148,7 @@ export const DarkMode = ({ api }: DarkModeProps) => {
       const current =
         mode || (currentStore.current === 'dark' ? 'light' : 'dark');
 
-      update({ ...currentStore, current });
+      updateStore({ ...currentStore, current });
       setMode(current);
     },
     [setMode]

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -74,7 +74,7 @@ const updatePreview = (store: DarkModeStore) => {
 
 /** Update the manager iframe class */
 const updateManager = (store: DarkModeStore) => {
-  const manager = document.getElementById('body') as HTMLBodyElement;
+  const manager = document.querySelector('body');
 
   if (!manager) {
     return;

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -34,7 +34,7 @@ interface DarkModeStore {
 const STORAGE_KEY = 'sb-addon-themes-3';
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-const defaultParams: Partial<DarkModeStore> = {
+const defaultParams: Required<Omit<DarkModeStore, 'current'>> = {
   dark: themes.dark,
   darkClass: 'dark',
   light: themes.light,
@@ -48,7 +48,7 @@ const updateStore = (newStore: DarkModeStore) => {
 };
 
 /** Add the light/dark class to an element */
-const toggleDarkClass = (el: HTMLElement, { current, darkClass, lightClass }: DarkModeStore) => {
+const toggleDarkClass = (el: HTMLElement, { current, darkClass = defaultParams.darkClass, lightClass = defaultParams.lightClass }: DarkModeStore) => {
   if (current === 'dark') {
     el.classList.add(darkClass);
     el.classList.remove(lightClass);
@@ -119,7 +119,6 @@ export const DarkMode = ({ api }: DarkModeProps) => {
   const { current: defaultMode, stylePreview, ...params } = useParameter<
     Partial<DarkModeStore>
   >('darkMode', defaultParams);
-  // const lastMode = React.useRef(defaultMode);
 
   // Save custom themes on init
   const initialMode = React.useRef(store(params).current);


### PR DESCRIPTION
This PR makes the work done in #102 optional and off by default. It also applies the dark/light class to the manager. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.1-canary.107.1984.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-dark-mode@0.5.1-canary.107.1984.0
  # or 
  yarn add storybook-dark-mode@0.5.1-canary.107.1984.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
