### PR TITLE
useDarkMode: read default isDark value from local storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 coverage
 dist/
+
+# IDE files
+.idea/

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -84,7 +84,7 @@ const updateManager = (store: DarkModeStore) => {
 };
 
 /** Update changed dark mode settings and persist to localStorage  */
-const store = (userTheme: Partial<DarkModeStore> = {}): DarkModeStore => {
+export const store = (userTheme: Partial<DarkModeStore> = {}): DarkModeStore => {
   const storedItem = window.localStorage.getItem(STORAGE_KEY);
 
   if (typeof storedItem === 'string') {
@@ -127,7 +127,6 @@ export const DarkMode = ({ api }: DarkModeProps) => {
   const setMode = React.useCallback(
     (mode: Mode) => {
       const currentStore = store();
-      console.log('set', mode);
       api.setOptions({ theme: currentStore[mode] });
       setDark(mode === 'dark');
       api.getChannel().emit(DARK_MODE_EVENT_NAME, mode === 'dark');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import addons from '@storybook/addons';
 import { DARK_MODE_EVENT_NAME } from './constants';
+import { store } from './Tool';
 
 /**
  * Returns the current state of storybook's dark-mode
  */
 export function useDarkMode(): boolean {
-  const [isDark, setDark] = React.useState(false);
+  const [isDark, setDark] = React.useState(store().current === 'dark');
 
   React.useEffect(() => {
     const chan = addons.getChannel();


### PR DESCRIPTION
Read default isDark value for `useDarkMode` hook from local storage.

Fixes #109.