### PR TITLE
Fixing brand theming in light mode

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -116,9 +116,8 @@ interface DarkModeProps {
 /** A toolbar icon to toggle between dark and light themes in storybook */
 export const DarkMode = ({ api }: DarkModeProps) => {
   const [isDark, setDark] = React.useState(prefersDark.matches);
-  const { current: defaultMode, stylePreview, ...params } = useParameter<
-    Partial<DarkModeStore>
-  >('darkMode', defaultParams);
+  const darkModeParams = useParameter<Partial<DarkModeStore>>('darkMode', defaultParams);
+  const { current: defaultMode, stylePreview, ...params } = darkModeParams
 
   // Save custom themes on init
   const initialMode = React.useRef(store(params).current);
@@ -158,10 +157,18 @@ export const DarkMode = ({ api }: DarkModeProps) => {
   }
 
   /** Render the current theme */
-  function renderTheme() {
+  const renderTheme = React.useCallback(()  => {
     const { current = 'light' } = store();
     setMode(current);
-  }
+  }, [setMode])
+
+  /** When storybook params change update the stored themes */
+  React.useEffect(() => {
+    const currentStore = store();
+
+    updateStore({ ...currentStore, ...darkModeParams });
+    renderTheme()
+  }, [darkModeParams, renderTheme])
 
   React.useEffect(() => {
     const channel = api.getChannel();

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -169,13 +169,13 @@ export const DarkMode = ({ api }: DarkModeProps) => {
     channel.on(STORY_CHANGED, renderTheme);
     channel.on(SET_STORIES, renderTheme);
     channel.on(DOCS_RENDERED, renderTheme);
-    prefersDark.addListener(prefersDarkUpdate);
+    prefersDark.addEventListener('change', prefersDarkUpdate);
 
     return () => {
       channel.removeListener(STORY_CHANGED, renderTheme);
       channel.removeListener(SET_STORIES, renderTheme);
       channel.removeListener(DOCS_RENDERED, renderTheme);
-      prefersDark.removeListener(prefersDarkUpdate);
+      prefersDark.removeEventListener('change', prefersDarkUpdate);
     };
   });
 

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -159,7 +159,7 @@ export const DarkMode = ({ api }: DarkModeProps) => {
 
   /** Render the current theme */
   function renderTheme() {
-    const { current } = store();
+    const { current = 'light' } = store();
     setMode(current);
   }
 


### PR DESCRIPTION
It looks like the story params update with the brand after the first render. This PR adds an effect that will update the store if the params change
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.121.2504.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-dark-mode@1.0.1-canary.121.2504.0
  # or 
  yarn add storybook-dark-mode@1.0.1-canary.121.2504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
