### PR TITLE
Ship source files for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "source": "index.ts",
   "files": [
+    "src",
     "dist",
     "register.js"
   ],


### PR DESCRIPTION
The `dist/` contains source-maps, but the underlying source files aren't present which causes webpack to complain 

```
WARNING in ./node_modules/storybook-dark-mode/dist/icons/Moon.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find source file '../../src/icons/Moon.tsx': Error: Can't resolve '../../src/icons/Moon.tsx' in '/Users/adierkens/Developer/rewrite/web/node_modules/storybook-dark-mode/dist/icons'
 @ ./node_modules/storybook-dark-mode/dist/Tool.js 59:29-52
 @ ./node_modules/storybook-dark-mode/dist/index.js
 @ ./packages/storybook/dist/esm/addons/docs/index.js
 @ ./packages/storybook/dist/esm/addons/index.js
 @ ./packages/storybook/dist/esm/index.js
 @ ./.storybook/config.js
 @ ./node_modules/@design-systems/storybook/.storybook/config.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./node_modules/@design-systems/storybook/.storybook/config.js ./node_modules/webpack-hot-middleware/client.js?reload=true&quiet=true ./node_modules/storybook-addon-sketch/entry.js
```