### PR TITLE
Change presets field to addons in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then, add following content to `.storybook/main.js`
 
 ```js
 module.exports = {
-  presets: ['storybook-dark-mode']
+  addons: ['storybook-dark-mode']
 };
 ```
 


### PR DESCRIPTION
In newest versions of Storybook it looks like presets changed to the addons field inside `.storybook/main.js` config file