### PR TITLE
Fix "color function invalid arg" issue when upgrading between versions of storybook

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,15 +1,18 @@
 import addons, { types } from '@storybook/addons';
+import { themes } from '@storybook/theming';
 import * as React from 'react';
 
 import Tool, { prefersDark, store } from './Tool';
 
 const currentStore = store();
+const currentTheme =
+  currentStore.current || (prefersDark.matches && 'dark') || 'light';
 
 addons.setConfig({
-  theme:
-    currentStore[
-      currentStore.current || (prefersDark.matches && 'dark') || 'light'
-    ]
+  theme: {
+    ...themes[currentTheme],
+    ...currentStore[currentTheme]
+  }
 });
 
 addons.register('storybook/dark-mode', api => {


### PR DESCRIPTION
When setting initial theme extends from default storybook themes to account for new variables that aren't yet stored it localStorage from saved theme. This will be overriden once the plugin actually loads

closes #140
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.5-canary.142.3135.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-dark-mode@1.0.5-canary.142.3135.0
  # or 
  yarn add storybook-dark-mode@1.0.5-canary.142.3135.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
