### PR TITLE
Add parameter for classTarget to toggle iframe preview class

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ export parameters = {
 };
 ```
 
+### Preview class target
+
+This plugin will apply the dark/light class to the `<body>` element of the preview iframe. This can be configured with the `classTarget` parameter.
+The value will be passed to a `querySelector()` inside the iframe.
+
+This is useful if the `<body>` is styled according to a parent's class, in that case it can be set to `html`.
+
+```js
+export parameters = {
+  darkMode: {
+    classTarget: 'html'
+  }
+}
+```
+
 ## Story integration
 
 ### Preview ClassName

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -17,6 +17,8 @@ const modes = ['light', 'dark'] as const;
 type Mode = typeof modes[number];
 
 interface DarkModeStore {
+  /** The class target in the preview iframe */
+  classTarget: string;
   /** The current mode the storybook is set to */
   current: Mode;
   /** The dark theme for storybook */
@@ -35,6 +37,7 @@ const STORAGE_KEY = 'sb-addon-themes-3';
 export const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
 const defaultParams: Required<Omit<DarkModeStore, 'current'>> = {
+  classTarget: 'body',
   dark: themes.dark,
   darkClass: 'dark',
   light: themes.light,
@@ -67,9 +70,13 @@ const updatePreview = (store: DarkModeStore) => {
   }
 
   const iframeDocument = iframe.contentDocument || iframe.contentWindow?.document;
-  const body = iframeDocument?.body as HTMLBodyElement;
+  const target = iframeDocument?.querySelector(store.classTarget) as HTMLElement;
 
-  toggleDarkClass(body, store);
+  if (!target) {
+    return;
+  }
+
+  toggleDarkClass(target, store);
 };
 
 /** Update the manager iframe class */


### PR DESCRIPTION
Add a new parameter `classTarget`, which can be set to define where the dark class should be toggled inside the iframe document. Defaults to existing functionality, toggling the class on the iframe's `body`.

Closes #133.