### PR TITLE
Fix storybook peerDependencies semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "release": "auto shipit"
   },
   "peerDependencies": {
-    "@storybook/addons": ">= 6.x",
-    "@storybook/api": ">= 6.x",
-    "@storybook/components": ">= 6.x",
-    "@storybook/core-events": ">= 6.x",
-    "@storybook/theming": ">= 6.x"
+    "@storybook/addons": "^6.0.0",
+    "@storybook/api": "^6.0.0",
+    "@storybook/components": "^6.0.0",
+    "@storybook/core-events": "^6.0.0",
+    "@storybook/theming": "^6.0.0"
   },
   "dependencies": {
     "fast-deep-equal": "^3.0.0",


### PR DESCRIPTION
Current semver range in the `peerDependencies` for storybook gives the following warnings:
```
warning " > storybook-dark-mode@1.0.7" has unmet peer dependency "@storybook/addons@>= 6.x".
warning " > storybook-dark-mode@1.0.7" has unmet peer dependency "@storybook/api@>= 6.x".
warning " > storybook-dark-mode@1.0.7" has unmet peer dependency "@storybook/components@>= 6.x".
warning " > storybook-dark-mode@1.0.7" has unmet peer dependency "@storybook/core-events@>= 6.x".
warning " > storybook-dark-mode@1.0.7" has unmet peer dependency "@storybook/theming@>= 6.x".
```

I think `>= 6.x` is invalid semver range --> changed to `^6.0.0`.