### PR TITLE
Import addon as named

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons from '@storybook/addons';
+import {addons} from '@storybook/addons';
 import { DARK_MODE_EVENT_NAME } from './constants';
 import { store } from './Tool';
 

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,4 +1,4 @@
-import addons, { types } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 import { themes } from '@storybook/theming';
 import * as React from 'react';
 


### PR DESCRIPTION
It's [recommended](https://github.com/storybookjs/storybook/blob/0981b635eed95b48998b9a5fd6d67216802324fb/lib/addons/src/public_api.ts#L3) to use named imports for @storybook/addons, and in fact the default import causes problems with the vite storybook builder.  The testing I did was copying this change into my local project and confirming the vite builder worked correctly.