### PR TITLE
Persist current store value

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -177,8 +177,13 @@ export const DarkMode = ({ api }: DarkModeProps) => {
   /** When storybook params change update the stored themes */
   React.useEffect(() => {
     const currentStore = store();
-
-    updateStore({ ...currentStore, ...darkModeParams });
+    // Ensure we use the stores `current` value first to persist
+    // themeing between page loads and story changes.
+    updateStore({
+      ...currentStore,
+      ...darkModeParams,
+      current: currentStore.current || darkModeParams.current,
+    });
     renderTheme()
   }, [darkModeParams, renderTheme])
 


### PR DESCRIPTION
Update to useEffect to use the store's `current` value first before the default `current` in parameters. This allows the current value to persist between page refreshes and story navigation.