### PR TITLE
Null check window.matchMedia

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -38,7 +38,7 @@ interface DarkModeStore {
 }
 
 const STORAGE_KEY = 'sb-addon-themes-3';
-export const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+export const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)');
 
 const defaultParams: Required<Omit<DarkModeStore, 'current'>> = {
   classTarget: 'body',


### PR DESCRIPTION
The motivation behind this is for storybook-dark-mode to work in a test environment (jest, vitest) without global config