### PR TITLE
fix: use classTarget when updating manager too

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -102,7 +102,7 @@ const updatePreview = (store: DarkModeStore) => {
 
 /** Update the manager iframe class */
 const updateManager = (store: DarkModeStore) => {
-  const manager = document.querySelector('body');
+  const manager = document.querySelector(store.classTarget);
 
   if (!manager) {
     return;


### PR DESCRIPTION
fixes #174 

seems like the moment you import any `storybook-dark-mode` into the preview side of things, `updateManager` is causes the body tag to have the classname put on it.


if we specify

```tsx
export const parameters = {
  darkMode: {
      classTarget: 'html'
  },
};
```

Seems to me that what we really want is that only the `html` tag be manipulated.