### PR TITLE
Fix sun icon

### DIFF
--- a/src/icons/Sun.tsx
+++ b/src/icons/Sun.tsx
@@ -9,6 +9,7 @@ export function Sun() {
       enableBackground="new 0 0 129 129"
       style={{
         fill: 'currentColor',
+        height: 13,
       }}
     >
       <g>


### PR DESCRIPTION
In storybook v8, the sun icon is not displayed properly. The icons is not showing, the moon works fine.
The moon icon has an additional `style.height` property
```
style={{
  fill: 'currentColor',
  height: 13,
}}
```

This PR adds the same height to the sun icon