### PR TITLE
Fix `useDarkMode` to use correct channel

### DIFF
--- a/examples/basic/src/Button.stories.d.ts
+++ b/examples/basic/src/Button.stories.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="react" />
-declare const _default: {
-    title: string;
-};
-export default _default;
-export declare function Basic(): JSX.Element;

--- a/examples/basic/src/Button.stories.tsx
+++ b/examples/basic/src/Button.stories.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button type="button" {...props} />;
+}
 
 export default {
   title: 'Button',
-};
+  component: Button,
+} satisfies Meta;
 
-export function Basic() {
-  return <button type="button">Click me</button>;
-}
+export const Basic: StoryObj<typeof Button> = {
+  args: {
+    children: 'Click me',
+  }
+};

--- a/examples/basic/src/useDarkMode.stories.tsx
+++ b/examples/basic/src/useDarkMode.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useDarkMode } from '../../../src';
+
+function TestComponent() {
+  const isDark = useDarkMode() ;
+  return <div>Dark mode: {isDark ? 'on' : 'off'}</div>;
+}
+
+export default {
+  title: 'useDarkMode',
+  component: TestComponent,
+} satisfies Meta;
+
+export const Default = {} satisfies StoryObj;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { addons } from '@storybook/manager-api';
+import { addons } from '@storybook/preview-api';
 import { DARK_MODE_EVENT_NAME } from './constants';
 import { store } from './Tool';
 


### PR DESCRIPTION
Regression in v4.0.0, `useDarkMode` updates no longer propagate to the preview frame. Seems `addons` should be imported from `preview-api` and not `manager-api`. See added story to reproduce.