### PR TITLE
Fix for the "Storybook preview hooks can only be called inside decorators and story functions." error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { addons, useState } from '@storybook/preview-api';
+import { addons, useState, useEffect } from '@storybook/preview-api';
 import { DARK_MODE_EVENT_NAME } from './constants';
 import { store } from './Tool';
 
@@ -8,7 +8,7 @@ import { store } from './Tool';
 export function useDarkMode(): boolean {
   const [isDark, setIsDark] = useState(store().current === 'dark');
 
-  React.useEffect(() => {
+  useEffect(() => {
     const chan = addons.getChannel();
     chan.on(DARK_MODE_EVENT_NAME, setIsDark);
     return () => chan.off(DARK_MODE_EVENT_NAME, setIsDark);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { addons } from '@storybook/preview-api';
+import { addons, useState } from '@storybook/preview-api';
 import { DARK_MODE_EVENT_NAME } from './constants';
 import { store } from './Tool';
 
@@ -7,7 +6,7 @@ import { store } from './Tool';
  * Returns the current state of storybook's dark-mode
  */
 export function useDarkMode(): boolean {
-  const [isDark, setIsDark] = React.useState(store().current === 'dark');
+  const [isDark, setIsDark] = useState(store().current === 'dark');
 
   React.useEffect(() => {
     const chan = addons.getChannel();


### PR DESCRIPTION
## Context for a bug:

I'm using a custom decorator to set the `data-theme` attribute in the `html` element:
```jsx
// .storybook/preview.tsx

export const decorators = [
  (Story: ComponentType) => {
    const isDarkMode = useDarkMode();
    useEffect(() => {
      document.documentElement.dataset.theme = isDarkMode ? 'dark' : 'light';
    }, [isDarkMode]);
    return <Story />;
  },
];
```

When I add an interactivity to one of my components using hooks from `@storybook/preview-api`, for example the `useArgs`:
```jsx
export const Checkbox: Story = {
  args: {
    selected: false,
    onClick: fn(),
  },
  render: (args) => {
    const [{ selected }, updateArgs] = useArgs();
    const onClick = (id: string) => {
      updateArgs({ selected: !selected });
      args.onClick();
    };
    return <Checkbox {...args} selected={selected} onClick={onClick} />;
  },
};
```

## The bug:

Everything works properly until I switch the theme. When I switch it I'm getting an error `Storybook preview hooks can only be called inside decorators and story functions.`. I need to refresh the page to see the component with styles applied from the other theme. Looks like Storybook doesn't allow to use hooks from `@storybook/preview-api` when the story is nested into another component that use hooks imported directly from `react`

I've tested the fix on my project. Seems to fix the issue, as now I can switch themes and the components works without throwing any errors.

## Versions:
Storybook: 8.0.8
storybook-dark-mode: 4.0.1