### PR TITLE
Update import for addons type enum

### DIFF
--- a/src/preset/manager.tsx
+++ b/src/preset/manager.tsx
@@ -1,5 +1,4 @@
-import { addons } from '@storybook/manager-api';
-import { Addon_TypesEnum } from '@storybook/types';
+import { addons, types } from '@storybook/manager-api';
 import { themes } from '@storybook/theming';
 import * as React from 'react';
 
@@ -19,7 +18,7 @@ addons.setConfig({
 addons.register('storybook/dark-mode', (api) => {
   addons.add('storybook/dark-mode', {
     title: 'dark mode',
-    type: Addon_TypesEnum.TOOL,
+    type: types.TOOL,
     match: ({ viewMode }) => viewMode === 'story' || viewMode === 'docs',
     render: () => <Tool api={api} />,
   });


### PR DESCRIPTION
I was going through and upgrading packages for a project, storybook-dark-mode among them, and started getting this error:

```sh
    ../node_modules/storybook-dark-mode/dist/esm/preset/manager.js:8:32:
      8 │ import { Addon_TypesEnum } from '@storybook/types';
        ╵                                 ~~~~~~~~~~~~~~~~~~

  You can mark the path "@storybook/types" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle.

Error: Build failed with 1 error:
../node_modules/storybook-dark-mode/dist/esm/preset/manager.js:8:32: ERROR: Could not resolve "@storybook/types"
    at failureErrorWithLog (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:1477:15)
    at /home/runner/work/x/x/node_modules/esbuild/lib/main.js:946:25
    at runOnEndCallbacks (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:1317:45)
    at buildResponseToResult (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:944:7)
    at /home/runner/work/x/x/node_modules/esbuild/lib/main.js:971:16
    at responseCallbacks.<computed> (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:623:9)
    at handleIncomingPacket (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:678:12)
    at Socket.readFromStdout (/home/runner/work/x/x/node_modules/esbuild/lib/main.js:601:7)
    at Socket.emit (node:events:524:28)
    at addChunk (node:internal/streams/readable:561:12)
```

I was able to find that the `Addon_TypesEnum` was deprecated in https://github.com/storybookjs/storybook/issues/25362 

this PR fixes this by updating the import to the current import [shown in the documentation ](https://storybook.js.org/docs/addons/addons-api#addonsadd). I was unsure if and how to make this backwards compatible so this may be a breaking change. I was also unable to test this beyond using [`patch-package`](https://www.npmjs.com/package/patch-package) to fix this locally and get passed the build error.